### PR TITLE
Clear Path Bug

### DIFF
--- a/Assets/TileMaps/Scripts/Example/AbstractExampleGrid.cs
+++ b/Assets/TileMaps/Scripts/Example/AbstractExampleGrid.cs
@@ -72,6 +72,16 @@ namespace nickmaltbie.TileMaps.Example
     }
 
     /// <summary>
+    /// Current selection state of the pathfinding.
+    /// </summary>
+    public enum PathfindingSelectionState
+    {
+        Start,
+        End,
+        Playing,
+    }
+
+    /// <summary>
     /// Example grid of spawned prefabs.
     /// </summary>
     public abstract class AbstractExampleGrid : MonoBehaviour
@@ -131,7 +141,7 @@ namespace nickmaltbie.TileMaps.Example
         /// <summary>
         /// Toggle of current state in pathfinding.
         /// </summary>
-        protected int toggle = 0;
+        protected PathfindingSelectionState pathfindingSelectionState = PathfindingSelectionState.Start;
 
         /// <summary>
         /// Currently found path.
@@ -535,6 +545,7 @@ namespace nickmaltbie.TileMaps.Example
             // Clear out previous  path
             this.selected1 = null;
             this.selected2 = null;
+            this.pathfindingSelectionState = PathfindingSelectionState.Start;
 
             if (temp1 != null)
             {
@@ -571,22 +582,24 @@ namespace nickmaltbie.TileMaps.Example
                 return;
             }
 
-            if (this.toggle == 0)
+            switch (this.pathfindingSelectionState)
             {
-                this.ClearPath();
-                // Start new path
-                this.selected1 = location;
-                this.UpdateTileColor(location);
-            }
-            else if (this.toggle == 1)
-            {
-                this.selected2 = location;
-                this.UpdateTileColor(location);
+                case PathfindingSelectionState.Playing:
+                case PathfindingSelectionState.Start:
+                    this.ClearPath();
+                    // Start new path
+                    this.selected1 = location;
+                    this.UpdateTileColor(location);
+                    this.pathfindingSelectionState = PathfindingSelectionState.End;
+                    break;
+                case PathfindingSelectionState.End:
+                    this.selected2 = location;
+                    this.UpdateTileColor(location);
 
-                this.DrawPath();
+                    this.DrawPath();
+                    this.pathfindingSelectionState = PathfindingSelectionState.Playing;
+                    break;
             }
-
-            this.toggle = (this.toggle + 1) % 2;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Fixed a small bug when pressing clear path with only one element selected resulted in no path being able to be created the next time the player clicked on the screen.

# How Has This Been Tested?

Tested locally to ensure that when pressing the clear path button that the path was cleared out correctly and a new path could be selected properly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
